### PR TITLE
Add an extra_context argument to the validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ validator = kmsauth.KMSTokenValidator(
 validator.decrypt_token(username, token)
 ```
 
+If you're extending the common KMS auth token context, you can pass extra
+context into the validator:
+
+```python
+import kmsauth
+validator = kmsauth.KMSTokenValidator(
+    # KMS key to use for service authentication
+    'alias/authnz-production',
+    # KMS key to use for user authentication
+    'alias/authnz-users-production',
+    # The context of this validation (the "to" context to validate against)
+    'confidant-production',
+    # Find the KMS keys in this region
+    'us-east-1',
+    extra_context={'action': 'create_resource'}
+)
+validator.decrypt_token(username, token)
+```
+
+Note: 'to', 'from', and 'user_type' keys are not allowed to be set in
+extra_context.
+
 ## Reporting security vulnerabilities
 
 If you've found a vulnerability or a potential vulnerability in kmsauth

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -81,9 +81,9 @@ class KMSTokenValidator(object):
             self.extra_context = extra_context
         self.TOKENS = lru.LRUCache(4096)
         self.KEY_METADATA = {}
-        self._validate_validator()
+        self._validate()
 
-    def _validate_validator(self):
+    def _validate(self):
         for key in ['from', 'to', 'user_type']:
             if key in self.extra_context:
                 raise ConfigurationError(
@@ -319,9 +319,9 @@ class KMSTokenGenerator(object):
                 'kms',
                 region=self.region
             )
-        self._validate_generator()
+        self._validate()
 
-    def _validate_generator(self):
+    def _validate(self):
         for key in ['from', 'to']:
             if key not in self.auth_context:
                 raise ConfigurationError(

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -155,6 +155,15 @@ class KMSTokenValidator(object):
             raise TokenValidationError('Unsupported username format.')
         return version, user_type, _from
 
+    def get_username_field(self, username, field):
+        version, user_type, _from = self._parse_username(username)
+        if field == 'from':
+            return _from
+        elif field == 'user_type':
+            return user_type
+        elif field == 'version':
+            return version
+
     def decrypt_token(self, username, token):
         '''
         Decrypt a token.

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -5,6 +5,7 @@ import datetime
 import base64
 import os
 import sys
+import copy
 
 import kmsauth.services
 from kmsauth.utils import lru
@@ -191,7 +192,7 @@ class KMSTokenValidator(object):
                 token = base64.b64decode(token)
                 # Ensure normal context fields override whatever is in
                 # extra_context.
-                context = self.extra_context
+                context = copy.deepcopy(self.extra_context)
                 context['to'] = self.to_auth_context
                 context['from'] = _from
                 if version > 1:

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -163,6 +163,7 @@ class KMSTokenValidator(object):
             return user_type
         elif field == 'version':
             return version
+        return None
 
     def decrypt_token(self, username, token):
         '''

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.1.4"
+VERSION = "0.1.5"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/tests/unit/kmsauth/kmsauth_test.py
+++ b/tests/unit/kmsauth/kmsauth_test.py
@@ -62,33 +62,6 @@ class KMSTokenValidatorTest(unittest.TestCase):
                 minimum_token_version=2,
                 maximum_token_version=1
             )
-        with self.assertRaises(kmsauth.ConfigurationError):
-            kmsauth.KMSTokenValidator(
-                'alias/authnz-unittest',
-                None,
-                'kmsauth-unittest',
-                'us-east-1',
-                # extra_context not allowed to have 'to'
-                extra_context={'to': 'me'}
-            )
-        with self.assertRaises(kmsauth.ConfigurationError):
-            kmsauth.KMSTokenValidator(
-                'alias/authnz-unittest',
-                None,
-                'kmsauth-unittest',
-                'us-east-1',
-                # extra_context not allowed to have 'from'
-                extra_context={'from': 'me'}
-            )
-        with self.assertRaises(kmsauth.ConfigurationError):
-            kmsauth.KMSTokenValidator(
-                'alias/authnz-unittest',
-                None,
-                'kmsauth-unittest',
-                'us-east-1',
-                # extra_context not allowed to have 'from'
-                extra_context={'user_type': 'user'}
-            )
         assert(kmsauth.KMSTokenValidator(
             'alias/authnz-unittest',
             None,

--- a/tests/unit/kmsauth/kmsauth_test.py
+++ b/tests/unit/kmsauth/kmsauth_test.py
@@ -62,6 +62,33 @@ class KMSTokenValidatorTest(unittest.TestCase):
                 minimum_token_version=2,
                 maximum_token_version=1
             )
+        with self.assertRaises(kmsauth.ConfigurationError):
+            kmsauth.KMSTokenValidator(
+                'alias/authnz-unittest',
+                None,
+                'kmsauth-unittest',
+                'us-east-1',
+                # extra_context not allowed to have 'to'
+                extra_context={'to': 'me'}
+            )
+        with self.assertRaises(kmsauth.ConfigurationError):
+            kmsauth.KMSTokenValidator(
+                'alias/authnz-unittest',
+                None,
+                'kmsauth-unittest',
+                'us-east-1',
+                # extra_context not allowed to have 'from'
+                extra_context={'from': 'me'}
+            )
+        with self.assertRaises(kmsauth.ConfigurationError):
+            kmsauth.KMSTokenValidator(
+                'alias/authnz-unittest',
+                None,
+                'kmsauth-unittest',
+                'us-east-1',
+                # extra_context not allowed to have 'from'
+                extra_context={'user_type': 'user'}
+            )
         assert(kmsauth.KMSTokenValidator(
             'alias/authnz-unittest',
             None,


### PR DESCRIPTION
Add an extra_context argument to the validator constructor, to allow for extended context in kms auth tokens.
