### PR TITLE
add kms performance parameters

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 on: pull_request
 jobs:
   pre-commit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -14,7 +14,7 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['2.x', '3.6.x', '3.7.x', '3.8.x']

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ validator.decrypt_token(username, token)
 Note: 'to', 'from', and 'user_type' keys are not allowed to be set in
 extra_context.
 
+## Performance Tuning
+
+With the [boto defaults](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html), the AWS KMS client used in `KMSTokenValidator` may not be performant under higher loads, due to latency when communicating with AWS KMS. Try tuning these parameters below with the given starting points.
+
+```python
+...
+max_pool_connections=100,
+connect_timeout=1,
+read_timeout=1,
+...
+```
+
 ## Reporting security vulnerabilities
 
 If you've found a vulnerability or a potential vulnerability in kmsauth

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -57,7 +57,9 @@ class KMSTokenValidator(object):
             endpoint_url=None,
             token_cache_size=4096,
             stats=None,
-            max_pool_connections=100
+            max_pool_connections=100,
+            connect_timeout=1,
+            read_timeout=1,
             ):
         """Create a KMSTokenValidator object.
 
@@ -109,14 +111,18 @@ class KMSTokenValidator(object):
                 aws_secret_access_key=self.aws_creds['SecretAccessKey'],
                 aws_session_token=self.aws_creds['SessionToken'],
                 endpoint_url=endpoint_url,
-                max_pool_connections=max_pool_connections
+                max_pool_connections=max_pool_connections,
+                connect_timeout=connect_timeout,
+                read_timeout=read_timeout,
             )
         else:
             self.kms_client = kmsauth.services.get_boto_client(
                 'kms',
                 region=self.region,
                 endpoint_url=endpoint_url,
-                max_pool_connections=max_pool_connections
+                max_pool_connections=max_pool_connections,
+                connect_timeout=connect_timeout,
+                read_timeout=read_timeout,
             )
         if extra_context is None:
             self.extra_context = {}

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -57,9 +57,9 @@ class KMSTokenValidator(object):
             endpoint_url=None,
             token_cache_size=4096,
             stats=None,
-            max_pool_connections=100,
-            connect_timeout=1,
-            read_timeout=1,
+            max_pool_connections=None,
+            connect_timeout=None,
+            read_timeout=None,
             ):
         """Create a KMSTokenValidator object.
 

--- a/kmsauth/__init__.py
+++ b/kmsauth/__init__.py
@@ -57,6 +57,7 @@ class KMSTokenValidator(object):
             endpoint_url=None,
             token_cache_size=4096,
             stats=None,
+            max_pool_connections=100
             ):
         """Create a KMSTokenValidator object.
 
@@ -107,13 +108,15 @@ class KMSTokenValidator(object):
                 aws_access_key_id=self.aws_creds['AccessKeyId'],
                 aws_secret_access_key=self.aws_creds['SecretAccessKey'],
                 aws_session_token=self.aws_creds['SessionToken'],
-                endpoint_url=endpoint_url
+                endpoint_url=endpoint_url,
+                max_pool_connections=max_pool_connections
             )
         else:
             self.kms_client = kmsauth.services.get_boto_client(
                 'kms',
                 region=self.region,
-                endpoint_url=endpoint_url
+                endpoint_url=endpoint_url,
+                max_pool_connections=max_pool_connections
             )
         if extra_context is None:
             self.extra_context = {}

--- a/kmsauth/services.py
+++ b/kmsauth/services.py
@@ -15,7 +15,9 @@ def get_boto_client(
         aws_secret_access_key=None,
         aws_session_token=None,
         endpoint_url=None,
-        max_pool_connections=None
+        max_pool_connections=None,
+        connect_timeout=None,
+        read_timeout=None,
         ):
     """Get a boto3 client connection."""
     cache_key = '{0}:{1}:{2}:{3}'.format(
@@ -41,7 +43,9 @@ def get_boto_client(
         client,
         endpoint_url=endpoint_url,
         config=botocore.config.Config(
-            max_pool_connections=max_pool_connections
+            max_pool_connections=max_pool_connections,
+            connect_timeout=connect_timeout,
+            read_timeout=read_timeout,
         )
     )
     return CLIENT_CACHE[cache_key]

--- a/kmsauth/services.py
+++ b/kmsauth/services.py
@@ -1,6 +1,7 @@
 """Module for accessing boto3 clients, resources and sessions."""
 
 import boto3
+import botocore
 import logging
 
 CLIENT_CACHE = {}
@@ -13,7 +14,8 @@ def get_boto_client(
         aws_access_key_id=None,
         aws_secret_access_key=None,
         aws_session_token=None,
-        endpoint_url=None
+        endpoint_url=None,
+        max_pool_connections=None
         ):
     """Get a boto3 client connection."""
     cache_key = '{0}:{1}:{2}:{3}'.format(
@@ -37,7 +39,10 @@ def get_boto_client(
 
     CLIENT_CACHE[cache_key] = session.client(
         client,
-        endpoint_url=endpoint_url
+        endpoint_url=endpoint_url,
+        config=botocore.config.Config(
+            max_pool_connections=max_pool_connections
+        )
     )
     return CLIENT_CACHE[cache_key]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.2.dev2"
+VERSION = "0.6.2"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.1.dev1"
+VERSION = "0.6.1.dev2"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.0"
+VERSION = "0.6.1.dev1"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.2.dev3"
+VERSION = "0.6.2.dev1"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.2.dev1"
+VERSION = "0.6.2.dev2"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
Editing the `KMSTokenValidator` to allow the boto `Config` object to customizable.

For a web server use case, such as within [lyft/confidant](https://github.com/lyft/confidant/blob/59bae423ae9c7c3f8a2967548e2c9d812c97729a/confidant/settings.py#L460-L468), some good values are

```
max_pool_connections=100,
connect_timeout=1,
read_timeout=1,
```

The [boto defaults](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html) are 10, 60, 60 respectively.
