### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 on: pull_request
 jobs:
   pre-commit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -14,7 +14,7 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['2.x', '3.6.x', '3.7.x', '3.8.x']

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['2.x', '3.6.x', '3.7.x', '3.8.x']
+        python-version: ['3.7.x', '3.8.x', '3.9.x', '3.10.x', '3.11.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-publish-python-module:
     name: Build and publish python module to pypi
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: '^docs/.*$'
 repos:
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     -   id: flake8

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,4 @@ test_unit:
 	mkdir -p build
 	coverage run -m pytest tests/unit
 	coverage xml
+	coverage report

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,5 @@ test: test_unit
 
 test_unit:
 	mkdir -p build
-	nosetests --with-coverage tests/unit
+	coverage run -m pytest tests/unit
+	coverage xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ pep8==1.5.7
 # nose makes testing easier
 # License: GNU Library or Lesser General Public License (LGPL)
 # Upstream url: http://readthedocs.org/docs/nose
-nose==1.3.7
+# nose==1.3.7
 
-# Mocking and Patching Library for Testing
-# License: BSD
-# Upstream url: http://www.voidspace.org.uk/python/mock
-mock==1.0.1
+# Testing library
+# License: MIT
+# Upstream url: https://github.com/pytest-dev/pytest
+pytest==6.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 
 [coverage:report]
-fail_under = 40
+fail_under = 70
 
 [coverage:xml]
 output = build/coverage.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,13 @@
 # Project specific configuration used by the following tools:
-#   - nosetests
+#   - pytest
 #   - flake8
-#
-# nosetests only support setup.cfg. flake8 supports both setup.cfg and tox.ini. In
-# In order to not have too many files around, we'll use setup.cfg for now.
 
-[nosetests]
-# Turn this back on if the logs to too spammy.
-#nocapture=1
-with-xunit = 1
-xunit-file = build/nosetests.xml
-cover-package = kmsauth
-cover-xml = 1
-cover-xml-file = build/coverage.xml
-cover-min-percentage = 70
+
+[coverage:report]
+fail_under = 40
+
+[coverage:xml]
+output = build/coverage.xml
 
 [flake8]
 # The jenkins violations plugin can read the pylint format.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.0"
+VERSION = "0.6.1"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/tests/unit/kmsauth/kmsauth_test.py
+++ b/tests/unit/kmsauth/kmsauth_test.py
@@ -3,8 +3,8 @@ import datetime
 import json
 
 import unittest
-from mock import patch
-from mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import kmsauth
 from kmsauth.utils import lru


### PR DESCRIPTION
- Upgrades base image for github workflows to 22.04 from 18.04 which has already expired.
  - https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
- start using pytest instead of the outddated nose
- flake8 pre-commit: gitlab -> github
