### PR TITLE
fix: don't set Config params when None

### DIFF
--- a/kmsauth/services.py
+++ b/kmsauth/services.py
@@ -19,7 +19,7 @@ def get_boto_client(
         connect_timeout=None,
         read_timeout=None,
         ):
-    """Get a boto3 client connection."""
+"""Get a boto3 client connection."""
     cache_key = '{0}:{1}:{2}:{3}'.format(
         client,
         region,
@@ -39,7 +39,7 @@ def get_boto_client(
         logging.error("Failed to get {0} client.".format(client))
         return None
 
-    # do not explicitly set any parmas as None
+    # do not explicitly set any params as None
     config_params = dict(
         max_pool_connections=max_pool_connections,
         connect_timeout=connect_timeout,

--- a/kmsauth/services.py
+++ b/kmsauth/services.py
@@ -19,7 +19,7 @@ def get_boto_client(
         connect_timeout=None,
         read_timeout=None,
         ):
-"""Get a boto3 client connection."""
+    """Get a boto3 client connection."""
     cache_key = '{0}:{1}:{2}:{3}'.format(
         client,
         region,

--- a/kmsauth/services.py
+++ b/kmsauth/services.py
@@ -39,14 +39,17 @@ def get_boto_client(
         logging.error("Failed to get {0} client.".format(client))
         return None
 
+    # do not explicitly set any parmas as None
+    config_params = dict(
+        max_pool_connections=max_pool_connections,
+        connect_timeout=connect_timeout,
+        read_timeout=read_timeout,
+    )
+    config_params = {k: v for (k, v) in config_params.items() if v is not None}
     CLIENT_CACHE[cache_key] = session.client(
         client,
         endpoint_url=endpoint_url,
-        config=botocore.config.Config(
-            max_pool_connections=max_pool_connections,
-            connect_timeout=connect_timeout,
-            read_timeout=read_timeout,
-        )
+        config=botocore.config.Config(**config_params)
     )
     return CLIENT_CACHE[cache_key]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.6.2"
+VERSION = "0.6.3"
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
Fix from https://github.com/lyft/python-kmsauth/pull/18

The previous change introduced Config options, but was explicitly setting them to `None` by default.
This breaks boto's expectations. For `max_pool_connections` it is fine to set to `None`, but problematic for `connect_timeout` and `read_timeout`, where [docs](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config) indicate that automatic `None` handling is not done for those parameters.

> connect_timeout (float or int) – The time in seconds till a timeout exception is thrown when attempting to make a connection. The default is 60 seconds.
> 
> read_timeout (float or int) – The time in seconds till a timeout exception is thrown when attempting to read from a connection. The default is 60 seconds.
> 
> ...
> 
> max_pool_connections (int) – The maximum number of connections to keep in a connection pool. If this value is not set, the default value of 10 is used.

This PR keeps the Validator's interface the same, but avoids setting any None parameters into the boto Config.